### PR TITLE
Fix export modal

### DIFF
--- a/src/obsidian/dashboards-view.tsx
+++ b/src/obsidian/dashboards-view.tsx
@@ -138,9 +138,9 @@ export default class DashboardsView extends TextFileView {
 		if (this.root) {
 			this.root.render(
 				<DashboardApp
-					leaf={this.leaf}
+					mountLeaf={this.leaf}
 					appId={appId}
-					filePath={this.file.path}
+					tableFile={this.file}
 					isMarkdownView={false}
 					store={store}
 					dashboardState={state}

--- a/src/obsidian/editing-view-plugin.tsx
+++ b/src/obsidian/editing-view-plugin.tsx
@@ -172,8 +172,8 @@ class EditingViewPlugin implements PluginValue {
 			<DashboardApp
 				appId={id}
 				isMarkdownView
-				filePath={dashboardFile.path}
-				leaf={leaf}
+				tableFile={dashboardFile}
+				mountLeaf={leaf}
 				store={store}
 				dashboardState={dashboardState}
 				onSaveState={(appId, state) =>

--- a/src/obsidian/editing-view-plugin.tsx
+++ b/src/obsidian/editing-view-plugin.tsx
@@ -43,7 +43,6 @@ class EditingViewPlugin implements PluginValue {
 
 	//This is ran on any editor change
 	update() {
-		console.log("update() called");
 		const markdownLeaves = app.workspace.getLeavesOfType("markdown");
 		const activeLeaf = markdownLeaves.find(
 			//@ts-expect-error - private property

--- a/src/obsidian/reading-view-child.tsx
+++ b/src/obsidian/reading-view-child.tsx
@@ -41,9 +41,9 @@ export default class ReadingViewChild extends MarkdownRenderChild {
 
 			this.root.render(
 				<DashboardApp
-					leaf={activeView.leaf}
+					mountLeaf={activeView.leaf}
 					appId={this.appId}
-					filePath={file.path}
+					tableFile={file}
 					isMarkdownView
 					store={store}
 					dashboardState={state}

--- a/src/react/dashboard-app/bottom-bar/index.tsx
+++ b/src/react/dashboard-app/bottom-bar/index.tsx
@@ -51,9 +51,6 @@ export default function BottomBar({
 		};
 	}, [ref]);
 
-	const footerRect = ref.current?.getBoundingClientRect();
-	console.log(spaceBetweenTableAndContainer);
-
 	const { isMarkdownView } = useMountState();
 
 	return (

--- a/src/react/dashboard-app/index.tsx
+++ b/src/react/dashboard-app/index.tsx
@@ -1,4 +1,4 @@
-import { WorkspaceLeaf } from "obsidian";
+import { TFile, WorkspaceLeaf } from "obsidian";
 
 import { Provider } from "react-redux";
 import { Store } from "@reduxjs/toolkit";
@@ -12,9 +12,9 @@ import App from "./app";
 
 interface Props {
 	appId: string;
-	leaf: WorkspaceLeaf;
+	mountLeaf: WorkspaceLeaf;
 	isMarkdownView: boolean;
-	filePath: string;
+	tableFile: TFile;
 	store: Store;
 	dashboardState: DashboardState;
 	onSaveState: (appId: string, state: DashboardState) => void;
@@ -22,19 +22,19 @@ interface Props {
 
 export default function DashboardApp({
 	appId,
-	leaf,
+	mountLeaf,
 	isMarkdownView,
 	store,
-	filePath,
+	tableFile,
 	dashboardState,
 	onSaveState,
 }: Props) {
 	return (
 		<MountProvider
-			leaf={leaf}
+			mountLeaf={mountLeaf}
 			appId={appId}
 			isMarkdownView={isMarkdownView}
-			filePath={filePath}
+			tableFile={tableFile}
 		>
 			<Provider store={store}>
 				<DashboardStateProvider

--- a/src/react/dashboard-app/mount-provider.tsx
+++ b/src/react/dashboard-app/mount-provider.tsx
@@ -1,10 +1,10 @@
-import { WorkspaceLeaf } from "obsidian";
+import { TFile, WorkspaceLeaf } from "obsidian";
 import React from "react";
 
 interface ContextProps {
-	leaf: WorkspaceLeaf;
+	mountLeaf: WorkspaceLeaf;
 	appId: string;
-	filePath: string;
+	tableFile: TFile;
 	isMarkdownView: boolean;
 }
 
@@ -27,14 +27,14 @@ interface Props extends ContextProps {
 
 export default function MountProvider({
 	appId,
-	leaf,
-	filePath,
+	mountLeaf,
+	tableFile,
 	isMarkdownView,
 	children,
 }: Props) {
 	return (
 		<MountContext.Provider
-			value={{ appId, leaf, filePath, isMarkdownView }}
+			value={{ appId, mountLeaf, tableFile, isMarkdownView }}
 		>
 			{children}
 		</MountContext.Provider>

--- a/src/react/dashboard-app/option-bar/index.tsx
+++ b/src/react/dashboard-app/option-bar/index.tsx
@@ -81,7 +81,7 @@ export default function OptionBar({
 	onRuleAddClick,
 	onRuleTagsChange,
 }: Props) {
-	const { filePath } = useMountState();
+	const { tableFile } = useMountState();
 	const sortedCells = headerCells.filter((cell) => {
 		const columnId = cell.columnId;
 		const column = columns.find((c) => c.id === columnId);
@@ -157,7 +157,7 @@ export default function OptionBar({
 							<Button
 								icon={<Icon lucideId="download" />}
 								onClick={() => {
-									new ExportModal(app, filePath).open();
+									new ExportModal(app, tableFile).open();
 								}}
 							></Button>
 						</Stack>

--- a/src/react/export-app/index.tsx
+++ b/src/react/export-app/index.tsx
@@ -18,10 +18,10 @@ import { useAppSelector } from "src/redux/global/hooks";
 
 interface Props {
 	dashboardState: DashboardState;
-	filePath: string;
+	tableFilePath: string;
 }
 
-export function ExportApp({ dashboardState, filePath }: Props) {
+export function ExportApp({ dashboardState, tableFilePath }: Props) {
 	const [exportType, setExportType] = React.useState<ExportType>(
 		ExportType.UNSELECTED
 	);
@@ -37,7 +37,7 @@ export function ExportApp({ dashboardState, filePath }: Props) {
 	}
 
 	function handleDownloadClick() {
-		const fileName = getExportFileName(filePath);
+		const fileName = getExportFileName(tableFilePath);
 		const blobType = getBlobTypeForExportType(exportType);
 		downloadFile(fileName, blobType, content);
 	}

--- a/src/shared/dashboard-state/use-export-events.ts
+++ b/src/shared/dashboard-state/use-export-events.ts
@@ -14,11 +14,12 @@ import { useMountState } from "../../react/dashboard-app/mount-provider";
 import { useAppSelector } from "src/redux/global/hooks";
 
 export const useExportEvents = (state: DashboardState) => {
-	const { filePath } = useMountState();
+	const { tableFile } = useMountState();
 	const { appId } = useMountState();
 	const { exportRenderMarkdown } = useAppSelector(
 		(state) => state.global.settings
 	);
+	const filePath = tableFile.path;
 
 	React.useEffect(() => {
 		function handleDownloadCSV() {

--- a/src/shared/menu/utils.ts
+++ b/src/shared/menu/utils.ts
@@ -30,8 +30,8 @@ export const useShiftMenu = (
 		leftOffset?: number;
 	}
 ) => {
-	const { leaf } = useMountState();
-	const viewContentEl = leaf.view.containerEl;
+	const { mountLeaf } = useMountState();
+	const viewContentEl = mountLeaf.view.containerEl;
 
 	React.useEffect(() => {
 		function shiftMenuIntoView() {

--- a/src/shared/render-utils.ts
+++ b/src/shared/render-utils.ts
@@ -80,15 +80,15 @@ export const useRenderMarkdown = (
 	const containerRef = React.useRef<HTMLDivElement | null>(null);
 	const renderRef = React.useRef<HTMLElement | null>(null);
 
-	const { leaf } = useMountState();
+	const { mountLeaf } = useMountState();
 
 	React.useEffect(() => {
 		async function updateContainerRef() {
 			let el = null;
 			if (isEmbed) {
-				el = await renderEmbed(leaf, markdown);
+				el = await renderEmbed(mountLeaf, markdown);
 			} else {
-				el = await renderMarkdown(leaf, markdown);
+				el = await renderMarkdown(mountLeaf, markdown);
 			}
 
 			if (el) {
@@ -102,7 +102,7 @@ export const useRenderMarkdown = (
 		}
 
 		updateContainerRef();
-	}, [markdown, leaf, isExternalLink, isEmbed]);
+	}, [markdown, mountLeaf, isExternalLink, isEmbed]);
 
 	return {
 		containerRef,


### PR DESCRIPTION
This update will fix the export modal not rendering anything in embedded table. This was due to it not being able to fetch the data from the file. We now pass the `tableFile` into the `DashboardApp` and that can be used by `app.vault.read()` in order to read file data. This is not dependent on the `DashboardView` having to be open