### PR TITLE
Fix csv export

### DIFF
--- a/src/react/export-app/index.tsx
+++ b/src/react/export-app/index.tsx
@@ -26,7 +26,7 @@ interface Props {
 	loomFilePath: string;
 }
 
-export function ExportApp({ loomState, loomFilePath }: Props) {
+export function ExportApp({ app, loomState, loomFilePath }: Props) {
 	const [exportType, setExportType] = React.useState<ExportType>(
 		ExportType.UNSELECTED
 	);

--- a/src/react/loom-app/app/hooks/use-export-events.ts
+++ b/src/react/loom-app/app/hooks/use-export-events.ts
@@ -27,9 +27,7 @@ export const useExportEvents = (state: LoomState) => {
 				setTimeout(() => {
 					const data = exportToCSV(app, state, exportRenderMarkdown);
 					const exportFileName = getExportFileName(filePath);
-					const blobType = getBlobTypeForExportType(
-						ExportType.MARKDOWN
-					);
+					const blobType = getBlobTypeForExportType(ExportType.CSV);
 					downloadFile(exportFileName, blobType, data);
 				}, 100);
 			}

--- a/src/shared/export/download-utils.ts
+++ b/src/shared/export/download-utils.ts
@@ -26,6 +26,10 @@ export const downloadFile = (
 	blobType: string,
 	data: string
 ) => {
+	if (blobType === "text/csv") {
+		//Add BOM to force Excel to open the file with UTF-8 encoding
+		data = "\uFEFF" + data;
+	}
 	//Create a blob object
 	const blob = new Blob([data], { type: blobType });
 	const url = window.URL.createObjectURL(blob);


### PR DESCRIPTION
This update fixes the mime type for the export event for csv.  The `text/markdown` mime was being used instead of `text/csv`. We also add the UTF-8 BOM to the start of the CSV file to force Microsoft Excel to import the file as UTF-8. This should fix issues with Chinese letters.