### PR TITLE
Optimize frontmatter

### DIFF
--- a/src/data/serialize-frontmatter.spec.ts
+++ b/src/data/serialize-frontmatter.spec.ts
@@ -113,7 +113,7 @@ describe("serializeFrontmatter", () => {
 		return state;
 	}
 
-	it("doesn't load content if frontmatter key is null", async () => {
+	it("doesn't serialize content if frontmatter key is null", async () => {
 		//Arrange
 		const state = createState(CellType.TEXT, null, [
 			{ content: "text-cell-1" },
@@ -128,7 +128,7 @@ describe("serializeFrontmatter", () => {
 		expect(frontmatterTest2).toEqual({});
 	});
 
-	it("doesn't load content if frontmatter key is empty", async () => {
+	it("doesn't serialize content if frontmatter key is empty", async () => {
 		//Arrange
 		const state = createState(CellType.TEXT, "", [
 			{ content: "text-cell-1" },
@@ -226,5 +226,20 @@ describe("serializeFrontmatter", () => {
 		expect(frontmatterTest2).toEqual({
 			tags: ["tag-1", "tag-2"],
 		});
+	});
+
+	it("doesn't serialize content if the frontmatter key doesn't exist and the content is empty", async () => {
+		//Arrange
+		const state = createState(CellType.TEXT, "text", [
+			{ content: "" },
+			{ content: "" },
+		]);
+
+		//Act
+		await serializeFrontmatter(app, state);
+
+		//Assert
+		expect(frontmatterTest1).toEqual({});
+		expect(frontmatterTest2).toEqual({});
 	});
 });

--- a/src/data/serialize-frontmatter.ts
+++ b/src/data/serialize-frontmatter.ts
@@ -62,6 +62,9 @@ export const serializeFrontmatter = async (app: App, state: LoomState) => {
 			}
 
 			await app.fileManager.processFrontMatter(file, (frontmatter) => {
+				//If it doesn't exist and the content is empty, skip it
+				if (!frontmatter[frontmatterKey.value] && !content) return;
+
 				frontmatter[frontmatterKey.value] = content;
 			});
 		}


### PR DESCRIPTION
**Fix**
- don't serialize frontmatter if the key doesn't exist on the file and the save content is empty. This drastically improves performance for folders with thousands of files.